### PR TITLE
port environment variable never used

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,6 @@ app.all("/badge", async (req, res) => {
     res.redirect(`https://img.shields.io/badge/version-${cached}-green&style=plastic`)
 })
 
-app.listen(3000 || process.env.PORT, () => {
-    console.log(`Started at http://localhost:${3000 || process.env.PORT}`)
+app.listen(process.env.PORT || 3000, () => {
+    console.log(`Started at http://localhost:${process.env.PORT || 3000}`)
 });


### PR DESCRIPTION
Code before:

```js
app.listen(3000 || process.env.PORT , () => {
    console.log(`Started at http://localhost:${3000 || process.env.PORT}`)
});
```

This would mean that `process.env.PORT` is used when `3000` doesn't "exist" but because it is there (it isn't "falsy"), the PORT environment variable is never used.

`process.env.PORT || 3000` fixes this because now it tries to use the environment variable first and if it doesn't exist, it uses 3000 as a backup.